### PR TITLE
SQLite database is now in-memory.

### DIFF
--- a/tests/DBTest.java
+++ b/tests/DBTest.java
@@ -23,7 +23,7 @@ import java.util.Vector;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DBTest {
-    Database db = new Database("testDB.db");
+    static Database db = new Database("testDB.db");
     
     @Test
     public void A0000redoDatabase() {
@@ -882,11 +882,16 @@ public class DBTest {
         // Delete the database if it doesn't already exist.
         Path dbPath = Paths.get("testDB.db");
         try {
-            Files.deleteIfExists(dbPath);
+        	Files.deleteIfExists(dbPath);
         }
         catch(Exception e) {
             e.printStackTrace();
         }
+    }
+    
+    @AfterClass
+    public static void saveDB() {
+    	db.saveDB();
     }
     
     public void addPatients(String filename) {


### PR DESCRIPTION
* By default, SQLite saves everything to disk every time we add things. This is
  Bad News Bears for speed. This update loads the database in memory. In the
  constructor, it loads the backup. db.saveDB() will save the backup to the same
  location that the constructor tried to load from.

* Speedup is remarkable - on my desktop computer, this makes the database
  constructor operation take 0.03 seconds as opposed to 2 seconds.

* The only tradeoff - upon termination of the program, you need to call saveDB.