### PR TITLE
Add space character to regexp validation.

### DIFF
--- a/src/com/psu/group9/Service.java
+++ b/src/com/psu/group9/Service.java
@@ -18,7 +18,7 @@ public class Service {
             exceptionString += "Code must be a six-digit integer.\n";
         }
         
-        if (!name.matches("[a-zA-Z]+")) {
+        if (!name.matches("[a-zA-Z ]+")) {
         	exceptionString += "Please enter valid Service name.";
         }
 


### PR DESCRIPTION
The regular expression needed a space character in it. 

Note that an error exists when listing the services from the Manager terminal only. There are test services named `Test1` and `Test2` which are now illegal since they contain numeric characters. I see instances of these in `DBTest.java` in lines 704 and 705, though I am not certain these are the root cause.