### PR TITLE
Makefile now creates reports folder inside zip.

### DIFF
--- a/createMakefile.py
+++ b/createMakefile.py
@@ -62,13 +62,16 @@ product:
 \tsh runTests.sh
 \t#Copy TestDB to database.db.
 \tcp testDB.db database.db
+\t#Create the reports folder.
+\tmkdir reports
 \t#Create the .zip out of the jar and the external libraries.
 \t
-\tzip -r CA.zip ExtLibs CA.jar database.db
+\tzip -r CA.zip ExtLibs reports CA.jar database.db
 \t
 \t#Remove the components that we've created along this route.
 \trm CA.jar
 \trm -rf ExtLibs
+\trm -rf reports
 
 clean:
 \trm src/com/psu/group9/*.class


### PR DESCRIPTION
To save reports, the Terminal saves inside a `reports` folder. This folder is currently absent, so the makefile now creates that when creating the zip.