### PR TITLE
Add Provider Directory save to Provider Terminal.

### DIFF
--- a/src/com/psu/group9/Terminal.java
+++ b/src/com/psu/group9/Terminal.java
@@ -803,9 +803,18 @@ public class Terminal {
                     addConsultation(db, provider);
                     break;
                 case 3: // List services
-                    System.out.println(getProivderDirectoryHeader());
-                    for (Service svc : db.getAllActiveServices())
+                    StringBuilder servicesForFile = new StringBuilder();
+                    Vector<Service> services = db.getAllServices();
+                    String headers = getProivderDirectoryHeader();
+                    servicesForFile.append(headers + "\n");         // file data *
+                    System.out.println(headers);
+                    for (Service svc : services) {
+                        servicesForFile.append(svc + "\n");           // file data *
                         System.out.println(svc);
+                    }
+                    writeToFile("provider_directory",
+                                servicesForFile.toString(),
+                                "Provider_Directory");             // file data * write
                     break;
                 case 4: // quit
                     System.out.println("Logging out of provider terminal\n");


### PR DESCRIPTION
Addresses #105. Saves Provider Directory to file when listed. This was added to the main provider menu, but the file is not saved when a provider lists services inside the consultation menu.